### PR TITLE
Increase padding to 40 whitespaces

### DIFF
--- a/progmeter.go
+++ b/progmeter.go
@@ -118,7 +118,7 @@ func (p *ProgMeter) AddEntryWithState(state, key, name, inf string) {
 }
 
 func (it *Item) Print(state string) {
-	fmt.Printf("\r[%s] %s%s", state, rightPad(it.Name, 35), it.Info)
+	fmt.Printf("\r[%s] %s%s", state, rightPad(it.Name, 40), it.Info)
 }
 
 func (p *ProgMeter) SetState(key, state string) {


### PR DESCRIPTION
We want to fix lines like:

```
[done] [install] go-libp2p-interface-conn QmfQAY7YU4fQi3sjGLs1hwkM2Aq7dxgDyoMjaKN4WBWvcB 0s
[done] [install] go-libp2p-interface-connmgrQmYkCrTwivapqdB3JbwvwvxymseahVkcm46ThRMAA24zCr 0s
[done] [install] go-libp2p-host           Qmc1XhrFEiSeBNn3mpfg6gEuYCt5im2gYmNVmncsvmpeAk 0s
```
where the library name is too long and cause a misalignment which hurts people eyes.